### PR TITLE
feat: Add function to return the configured default target org alias

### DIFF
--- a/lua/salesforcedx/init.lua
+++ b/lua/salesforcedx/init.lua
@@ -5,7 +5,18 @@ local salesforce = require("salesforcedx.salesforce")
 
 M = {}
 
+M.is_salesforce_project_directory = function()
+	local sfdx_project_file = vim.fn.getcwd() .. "/sfdx-project.json"
+
+	return vim.fn.filereadable(sfdx_project_file) == 1
+end
+
 M.execute_test_class = function()
+	if not M.is_salesforce_project_directory() then
+		vim.api.nvim_err_writeln("Not an sfdx project")
+		return
+	end
+
 	local current_node = ts_utils.get_node_at_cursor()
 
 	if not current_node then
@@ -26,6 +37,11 @@ M.execute_test_class = function()
 end
 
 M.execute_test_method = function()
+	if not M.is_salesforce_project_directory() then
+		vim.api.nvim_err_writeln("Not an sfdx project")
+		return
+	end
+
 	local current_node = ts_utils.get_node_at_cursor()
 
 	if not current_node then
@@ -53,9 +69,35 @@ M.execute_test_method = function()
 end
 
 M.deploy_start = function()
+	if not M.is_salesforce_project_directory() then
+		vim.api.nvim_err_writeln("Not an sfdx project")
+		return
+	end
+
 	local command = salesforce.get_project_deploy_start()
 	local bufnr = utils.create_split()
 	utils.execute_command(command, bufnr)
+end
+
+M.get_default_target_org = function()
+	if not M.is_salesforce_project_directory() then
+		return ""
+	end
+
+	local sf_config = vim.fn.getcwd() .. "/.sf/config.json"
+	if vim.fn.filereadable(sf_config) == 1 then
+		local file = io.open(sf_config, "r")
+		if not file then
+			return ""
+		end
+
+		local content = file:read("*all")
+		file:close()
+		local default_target_org = vim.json.decode(content)["target-org"]
+		return default_target_org
+	end
+
+	return ""
 end
 
 M.setup = function()

--- a/tests/e2e/deploy_start_spec.lua
+++ b/tests/e2e/deploy_start_spec.lua
@@ -1,4 +1,5 @@
 local stub = require("luassert.stub")
+local mock = require("luassert.mock")
 local match = require("luassert.match")
 
 local create_buffer_with_content = function(input)
@@ -20,10 +21,18 @@ public class MyTest {
 
 describe("deploy_start", function()
 	local sf = require("salesforcedx")
+	local vim_fn_mock = mock(vim.fn)
 
 	before_each(function()
 		create_buffer_with_content(test_class)
 		vim.cmd("set filetype=apex")
+		vim_fn_mock.filereadable = function()
+			return 1
+		end
+	end)
+
+	after_each(function()
+		mock.revert(vim_fn_mock)
 	end)
 
 	it("runs project deploy start command", function()

--- a/tests/e2e/test_class_spec.lua
+++ b/tests/e2e/test_class_spec.lua
@@ -1,5 +1,6 @@
 local stub = require("luassert.stub")
 local match = require("luassert.match")
+local mock = require("luassert.mock")
 
 local create_buffer_with_content = function(input)
 	local buf = vim.api.nvim_create_buf(false, true)
@@ -20,10 +21,18 @@ public class MyTest {
 
 describe("execute_test_class", function()
 	local sf = require("salesforcedx")
+	local vim_fn_mock = mock(vim.fn)
 
 	before_each(function()
 		create_buffer_with_content(test_class)
 		vim.cmd("set filetype=apex")
+		vim_fn_mock.filereadable = function()
+			return 1
+		end
+	end)
+
+	after_each(function()
+		mock.revert(vim_fn_mock)
 	end)
 
 	it("runs test class", function()

--- a/tests/e2e/test_method_spec.lua
+++ b/tests/e2e/test_method_spec.lua
@@ -1,5 +1,6 @@
 local stub = require("luassert.stub")
 local match = require("luassert.match")
+local mock = require("luassert.mock")
 
 local create_buffer_with_content = function(input)
 	local buf = vim.api.nvim_create_buf(false, true)
@@ -20,10 +21,18 @@ public class MyTest {
 
 describe("execute_test_method", function()
 	local sf = require("salesforcedx")
+	local vim_fn_mock = mock(vim.fn)
 
 	before_each(function()
 		create_buffer_with_content(test_class)
 		vim.cmd("set filetype=apex")
+		vim_fn_mock.filereadable = function()
+			return 1
+		end
+	end)
+
+	after_each(function()
+		mock.revert(vim_fn_mock)
 	end)
 
 	it("runs test method", function()


### PR DESCRIPTION
Add function that returns the configured default target org alias, as read from the `.sf/config.json` file in the Salesforce project directory.

Also add function that returns true when the current working directory is a Salesforce project.